### PR TITLE
text-support mixin should use on('didInsertElement')

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -76,6 +76,7 @@ export {
   EuiCheckboxComponent,
   EuiDropbuttonComponent,
   EuiInputComponent,
+  EuiInputTemplate,
   EuiModalComponent,
   EuiPoplistComponent,
   EuiSelectComponent,

--- a/lib/mixins/text-support.coffee
+++ b/lib/mixins/text-support.coffee
@@ -15,8 +15,9 @@ textsupport = Em.Mixin.create
   inputId: null
 
   # We need to bind the value of the label to the textarea's id because IE8 and IE9 doesn't support pointer-events: none;
-  didInsertElement: ->
+  setInputId: (->
     @set('inputId', @$('input').attr('id') or @$('textarea').attr('id'))
+  ).on('didInsertElement')
 
   placeholderVisible: Em.computed ->
     placeholder = @get('placeholder')

--- a/test/eui-input-test.js
+++ b/test/eui-input-test.js
@@ -6,3 +6,14 @@ test('starts with errorState null', function() {
   this.append();
   equal(input.get('errorState'), null);
 });
+
+test('inputId is stored on didInsertElement', function() {
+  expect(2);
+  var input = this.subject({
+    value: 'bonk',
+    error: true
+  });
+  ok(!input.get('inputId'), 'inputId is not set until append');
+  this.append()
+  ok(input.get('inputId'), 'inputId is set after append');
+});

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -4,7 +4,8 @@ emq.globalize();
 
 setResolver(Ember.DefaultResolver.extend({
   testSubjects: {
-    'component:eui-input': eui.EuiInputComponent
+    'component:eui-input': eui.EuiInputComponent,
+    'template:components/eui-input': eui.EuiInputTemplate
   },
   resolve: function(fullName) {
     return this.testSubjects[fullName] || this._super.apply(this, arguments);


### PR DESCRIPTION
this let's the mixener (?) implement their own version

I took the chance to add a simple test for this use case.
It turns out it's probably a good idea for us to export also the
templates as I'd rather test against the real templates than using a
fake version.

Thoughts? /cc @elucid @jacojoubert
