### PR TITLE
after discussion with @elucid, here's some minor style changes

### DIFF
--- a/lib/components/eui-calendar.coffee
+++ b/lib/components/eui-calendar.coffee
@@ -1,10 +1,9 @@
 `import styleSupport from '../mixins/style-support'`
 
 cpFormatMoment = (key, format) ->
-  return Em.computed( ->
+  return Em.computed 'key', ->
     date = @get(key)
     return if date then date.format(format) else null
-  ).property(key)
 
 
 calendar = Em.Component.extend styleSupport,
@@ -99,7 +98,7 @@ calendar = Em.Component.extend styleSupport,
       @set 'month', month.clone().add('months', 1)
 
 
-  selection: Ember.computed (key, value) ->
+  selection: Ember.computed '_selection', (key, value) ->
     # setter
     if arguments.length is 2
       if @get 'allowMultiple'
@@ -120,7 +119,6 @@ calendar = Em.Component.extend styleSupport,
 
       else
         return selection.get('firstObject')
-  .property '_selection'
 
 
   hasDate: (date) ->

--- a/lib/components/eui-dropbutton.coffee
+++ b/lib/components/eui-dropbutton.coffee
@@ -15,9 +15,8 @@ dropbutton = Em.Component.extend styleSupport, sizeSupport,
 
   # Action for the left button
 
-  primaryAction: Em.computed ->
+  primaryAction: Em.computed 'options', ->
     @get('options').findBy 'primary', true
-  .property 'options'
 
 
   # If the selection changes peform the action and reset it so it can get triggered
@@ -32,9 +31,8 @@ dropbutton = Em.Component.extend styleSupport, sizeSupport,
 
   # List of options without any primary actions
 
-  optionsWithoutPrimaryAction: Ember.computed.filter('options', (option) ->
+  optionsWithoutPrimaryAction: Ember.computed.filter 'options', (option) ->
     return not option.primary
-  ).property "options"
 
 
   actions:

--- a/lib/components/eui-modal.coffee
+++ b/lib/components/eui-modal.coffee
@@ -42,7 +42,7 @@ modal = Em.Component.extend styleSupport, animationsDidComplete,
   # Proxy for renderModal. Allows us to animate the modal closing by delaying the setting of
   # renderModal until the animation is done playing
 
-  open: Ember.computed (key, value) ->
+  open: Ember.computed 'renderModal', (key, value) ->
     # setter
     if arguments.length is 2
 
@@ -60,8 +60,6 @@ modal = Em.Component.extend styleSupport, animationsDidComplete,
     else
       value = @get 'renderModal'
       value
-
-  .property 'renderModal'
 
 
   # Initial setup when modal is shown programatically

--- a/lib/components/eui-poplist.coffee
+++ b/lib/components/eui-poplist.coffee
@@ -51,7 +51,7 @@ poplist = Em.Component.extend styleSupport, animationsDidComplete,
 
   # Option that is currently highlighted
 
-  highlighted: Ember.computed (key, value) ->
+  highlighted: Ember.computed 'highlightedIndex', 'filteredOptions', (key, value) ->
     options = @get 'filteredOptions'
 
     # setter
@@ -65,7 +65,6 @@ poplist = Em.Component.extend styleSupport, animationsDidComplete,
       index = @get 'highlightedIndex'
       options.objectAt index
 
-  .property 'highlightedIndex', 'filteredOptions'
 
 
   # Reset and remove Poplist from the DOM and unbind events bound during initialization.
@@ -316,14 +315,12 @@ poplist = Em.Component.extend styleSupport, animationsDidComplete,
         @set 'content', context
 
 
-      isHighlighted: Ember.computed ->
+      isHighlighted: Ember.computed 'controller.highlighted', 'content', ->
         @get('controller.highlighted') is @get('content')
-      .property 'controller.highlighted', 'content'
 
 
-      isSelected: Ember.computed ->
+      isSelected: Ember.computed 'controller.selection', 'content', ->
         @get('controller.selection') is @get('content')
-      .property 'controller.selection', 'content'
 
 
       click: ->

--- a/lib/components/eui-select.coffee
+++ b/lib/components/eui-select.coffee
@@ -56,7 +56,7 @@ select = Em.Component.extend disabledSupport, validationSupport,
   # which the poplist binds to. It allows us to return null when the user selects
   # the nullValue object we inserted.
 
-  selection: Ember.computed (key, value) ->
+  selection: Ember.computed '_selection', (key, value) ->
     # setter
     if arguments.length is 2
       @set '_selection', value
@@ -67,14 +67,13 @@ select = Em.Component.extend disabledSupport, validationSupport,
       selection = @get '_selection'
       nullValue = @get 'nullValue'
       if selection == nullValue then null else selection
-  .property '_selection'
 
 
   # Computes the value of the selection based on the valuePath specified by the user.
   # Allows for getting and setting so the user can set the initial value of the select
   # without passing in the full object
 
-  value: Ember.computed (key, value) ->
+  value: Ember.computed 'selection', 'valuePath', (key, value) ->
     # setter
     if arguments.length is 2
       valuePath = @get 'valuePath'
@@ -86,7 +85,6 @@ select = Em.Component.extend disabledSupport, validationSupport,
     else
       valuePath = @get 'valuePath'
       if valuePath then @get("selection.#{valuePath}") else null
-  .property 'selection', 'valuePath'
 
 
   initialization: (->

--- a/lib/components/eui-textarea.coffee
+++ b/lib/components/eui-textarea.coffee
@@ -10,7 +10,7 @@ textarea = Em.Component.extend validationSupport, textSupport, styleSupport, siz
 
   height: null
 
-  computedWidthAndHeight: Em.computed ->
+  computedWidthAndHeight: Em.computed 'size', 'width', 'height', ->
     widths =
       tiny: '100px'
       small: '150px'
@@ -26,6 +26,5 @@ textarea = Em.Component.extend validationSupport, textSupport, styleSupport, siz
     width = @get('width') or widths[@get('size')] or widths['medium']
     height = @get('height') or heights[@get('size')] or heights['medium']
     return "width: #{width}; height: #{height};"
-  .property 'size', 'width', 'height'
 
 `export default textarea`

--- a/lib/mixins/animations-did-complete.coffee
+++ b/lib/mixins/animations-did-complete.coffee
@@ -1,11 +1,11 @@
 animationsDidComplete = Em.Mixin.create
   # Returns a promise and resovles it once any animations that may be playing have
-  # compeleted.
+  # completed.
 
   animationsDidComplete: ->
-    promise = new Ember.RSVP.Promise (resolve, reject) =>
+    promise = new Em.RSVP.Promise (resolve, reject) =>
       animation = false
-      
+
       # Check only elements tagged with the eui-animation class
       primaryElement = @.$()
       animatedElements = @.$().find('.eui-animation')

--- a/lib/mixins/disabled-support.coffee
+++ b/lib/mixins/disabled-support.coffee
@@ -2,9 +2,8 @@ disabledsupport = Em.Mixin.create
   classNameBindings: ['isDisabled:eui-disabled']
   disabled: false
 
-  isDisabled:  Em.computed ->
+  isDisabled:  Em.computed 'disabled', 'loading', ->
     if @get('disabled') or @get('loading')
       return true
-  .property 'disabled', 'loading'
 
 `export default disabledsupport`

--- a/lib/mixins/size-support.coffee
+++ b/lib/mixins/size-support.coffee
@@ -2,8 +2,7 @@ sizesupport = Em.Mixin.create
   classNameBindings: ['computedSize']
   size: 'medium'
 
-  computedSize: Em.computed ->
+  computedSize: Em.computed 'size', ->
     return 'eui-' + @get('size')
-  .property 'size'
 
 `export default sizesupport`

--- a/lib/mixins/text-support.coffee
+++ b/lib/mixins/text-support.coffee
@@ -18,12 +18,11 @@ textsupport = Em.Mixin.create
   didInsertElement: ->
     @set('inputId', @$('input').attr('id') or @$('textarea').attr('id'))
 
-  placeholderVisible: Em.computed ->
+  placeholderVisible: Em.computed 'placeholder', 'value', ->
     placeholder = @get('placeholder')
     value = @get('value')
 
     if placeholder and !value
       return true
-  .property 'placeholder', 'value'
 
 `export default textsupport`

--- a/lib/mixins/width-support.coffee
+++ b/lib/mixins/width-support.coffee
@@ -1,7 +1,7 @@
 widthsupport = Em.Mixin.create
   attributeBindings: ['computedWidth:style']
 
-  computedWidth: Em.computed ->
+  computedWidth: Em.computed 'size', 'width', ->
     widths =
       tiny: '100px'
       small: '150px'
@@ -10,6 +10,5 @@ widthsupport = Em.Mixin.create
 
     width = @get('width') or widths[@get('size')] or widths['medium']
     return "width: #{width};"
-  .property 'size', 'width'
 
 `export default widthsupport`


### PR DESCRIPTION
mainly moving to uniform syntax for Em.computed 'prop1', 'prop2', ->
