### PR TITLE
Fixes a bug where an event handler is called when no targetObject exists on hiding a poplist

### DIFF
--- a/lib/components/eui-poplist.coffee
+++ b/lib/components/eui-poplist.coffee
@@ -70,10 +70,12 @@ poplist = Em.Component.extend styleSupport, animationSupport,
 
 
   hide: ->
-    @animateOut({
-      target: @get('targetObject').$()
-      complete: => @breakdown()
-    })
+    # Only hide if a targetOject exists to hide in the first place
+    if @get('targetObject')? 
+      @animateOut({
+        target: @get('targetObject').$()
+        complete: => @breakdown()
+      })
 
 
   setup: (->


### PR DESCRIPTION
Click a select -> select an option -> wait for the poplist to hide -> click outside -> $ called on undefined error. See the gif below:

![cry](http://recordit.co/tOQT8OFNot.gif)

Traces to here in eui-poplist.coffee:

```
  hide: ->
    # Only hide if a targetOject exists to hide in the first place
    if @get('targetObject')? 
      @animateOut({
        target: @get('targetObject').$()
        complete: => @breakdown()
      })   
```

So for some reason the event handler for click.ember-ui gets called - but no targetObject exists. My fix just guards hide() so it only executes if targetObject exists - but this seems bandaid-y.
