### PR TITLE
move initializer in separate module

### DIFF
--- a/lib/initializers/eui-initializer.js
+++ b/lib/initializers/eui-initializer.js
@@ -1,0 +1,77 @@
+import EuiButtonComponent from '../components/eui-button';
+import EuiButtonTemplate from '../templates/eui-button';
+
+import EuiCheckboxComponent from '../components/eui-checkbox';
+import EuiCheckboxTemplate from '../templates/eui-checkbox';
+
+import EuiDropbuttonComponent from '../components/eui-dropbutton';
+import EuiDropbuttonTemplate from '../templates/eui-dropbutton';
+
+import EuiInputComponent from '../components/eui-input';
+import EuiInputTemplate from '../templates/eui-input';
+
+import EuiModalComponent from '../components/eui-modal';
+import EuiModalTemplate from '../templates/eui-modal';
+
+import EuiPoplistComponent from '../components/eui-poplist';
+import EuiPoplistTemplate from '../templates/eui-poplist';
+import EuiPoplistOptionTemplate from '../templates/eui-poplist-option';
+
+import EuiSelectComponent from '../components/eui-select';
+import EuiSelectTemplate from '../templates/eui-select';
+
+import EuiSelectDateComponent from '../components/eui-selectdate';
+import EuiSelectDateTemplate from '../templates/eui-selectdate';
+
+import EuiTextareaComponent from '../components/eui-textarea';
+import EuiTextareaTemplate from '../templates/eui-textarea';
+
+import EuiMonthComponent from '../components/eui-month';
+
+import EuiCalendarComponent from '../components/eui-calendar';
+import EuiCalendarTemplate from '../templates/eui-calendar';
+
+import EuiPopcalComponent from '../components/eui-popcal';
+import EuiPopcalTemplate from '../templates/eui-popcal';
+
+export default {
+  name: 'emberui',
+
+  initialize: function(container) {
+    container.register('template:components/eui-button', EuiButtonTemplate);
+    container.register('component:eui-button', EuiButtonComponent);
+
+    container.register('template:components/eui-checkbox', EuiCheckboxTemplate);
+    container.register('component:eui-checkbox', EuiCheckboxComponent);
+
+    container.register('template:components/eui-dropbutton', EuiDropbuttonTemplate);
+    container.register('component:eui-dropbutton', EuiDropbuttonComponent);
+
+    container.register('template:components/eui-input', EuiInputTemplate);
+    container.register('component:eui-input', EuiInputComponent);
+
+    container.register('template:components/eui-modal', EuiModalTemplate);
+    container.register('component:eui-modal', EuiModalComponent);
+
+    container.register('template:components/eui-poplist', EuiPoplistTemplate);
+    container.register('template:components/eui-poplist-opion', EuiPoplistOptionTemplate);
+    container.register('component:eui-poplist', EuiPoplistComponent);
+
+    container.register('template:components/eui-select', EuiSelectTemplate);
+    container.register('component:eui-select', EuiSelectComponent);
+
+    container.register('template:components/eui-selectdate', EuiSelectDateTemplate);
+    container.register('component:eui-selectdate', EuiSelectDateComponent);
+
+    container.register('template:components/eui-popcal', EuiPopcalTemplate);
+    container.register('component:eui-popcal', EuiPopcalComponent);
+
+    container.register('template:components/eui-textarea', EuiTextareaTemplate);
+    container.register('component:eui-textarea', EuiTextareaComponent);
+
+    container.register('component:eui-month', EuiMonthComponent);
+
+    container.register('template:components/eui-calendar', EuiCalendarTemplate);
+    container.register('component:eui-calendar', EuiCalendarComponent);
+  }
+};

--- a/lib/main.js
+++ b/lib/main.js
@@ -52,52 +52,15 @@ import './animations/poplist-open-default';
 import './animations/poplist-close-flyin';
 import './animations/poplist-open-flyin';
 
+import EuiInitializer from './initializers/eui-initializer';
 
-Ember.Application.initializer({
-  name: 'emberui',
 
-  initialize: function(container) {
-    container.register('template:components/eui-button', EuiButtonTemplate);
-    container.register('component:eui-button', EuiButtonComponent);
-
-    container.register('template:components/eui-checkbox', EuiCheckboxTemplate);
-    container.register('component:eui-checkbox', EuiCheckboxComponent);
-
-    container.register('template:components/eui-dropbutton', EuiDropbuttonTemplate);
-    container.register('component:eui-dropbutton', EuiDropbuttonComponent);
-
-    container.register('template:components/eui-input', EuiInputTemplate);
-    container.register('component:eui-input', EuiInputComponent);
-
-    container.register('template:components/eui-modal', EuiModalTemplate);
-    container.register('component:eui-modal', EuiModalComponent);
-
-    container.register('template:components/eui-poplist', EuiPoplistTemplate);
-    container.register('template:components/eui-poplist-opion', EuiPoplistOptionTemplate);
-    container.register('component:eui-poplist', EuiPoplistComponent);
-
-    container.register('template:components/eui-select', EuiSelectTemplate);
-    container.register('component:eui-select', EuiSelectComponent);
-
-    container.register('template:components/eui-selectdate', EuiSelectDateTemplate);
-    container.register('component:eui-selectdate', EuiSelectDateComponent);
-
-    container.register('template:components/eui-popcal', EuiPopcalTemplate);
-    container.register('component:eui-popcal', EuiPopcalComponent);
-
-    container.register('template:components/eui-textarea', EuiTextareaTemplate);
-    container.register('component:eui-textarea', EuiTextareaComponent);
-
-    container.register('component:eui-month', EuiMonthComponent);
-
-    container.register('template:components/eui-calendar', EuiCalendarTemplate);
-    container.register('component:eui-calendar', EuiCalendarComponent);
-  }
-});
+Ember.Application.initializer(EuiInitializer);
 
 Ember.libraries.register('EmberUI', '0.1.2');
 
 export {
+  EuiInitializer,
   EuiButtonComponent,
   EuiCheckboxComponent,
   EuiDropbuttonComponent,


### PR DESCRIPTION
as discussed in #38 with the following it should be possible to use `ember-load-initializers` to load the emberui initializer without requiring it automatically

in other words

if you use `ember-cli`

it's currently possible to use the named-amd build of emberui with ember-cli

it's as simple as 

```
app.import('vendor/emberui/dist/named-amd/main.js', {  
  'emberui': ['default']                                         
});                                                                                                                                                                                                
app.import('vendor/emberui/dist/emberui.css');                                                                                                                                                         
app.import('vendor/emberui/dist/default-theme.css');  
```

but in order for the initalizer to trigger you then have to

```
loadInitializers(App, 'emberui');
```

the `main.js` build still loads the initializers instead so that the behaviour if you require the default module or use the `global` build it's maintained

/cc @jdjkelly @tonywok @elucid 
