### PR TITLE
Fix click event error

### DIFF
--- a/lib/components/eui-popcal.coffee
+++ b/lib/components/eui-popcal.coffee
@@ -52,10 +52,9 @@ popcal = Em.Component.extend styleSupport, animationSupport,
     # Bind to click event so we can close the popcal if the user clicks outside
     # it. Run next so popcal doesn't close immediately.
     Ember.run.next @, ->
-      $(window).on 'click.emberui', (event) =>
-        unless $(event.target).parents('.eui-popcal').length
+      $(window).one 'click.emberui', (event) =>
+        if @get('targetObject')? && !$(event.target).parents('.eui-popcal').length
           event.preventDefault()
-          $(window).off(event)
           @hide()
 
     # Focus on popcal to ensure we can catch keyboard input.

--- a/lib/components/eui-poplist.coffee
+++ b/lib/components/eui-poplist.coffee
@@ -110,10 +110,9 @@ poplist = Em.Component.extend styleSupport, animationSupport,
     # Bind to click event so we can close the poplist if the user click outside
     # it
     Ember.run.next @, ->
-      $(window).on 'click.emberui', (event) =>
-        unless $(event.target).parents('.eui-poplist').length
+      $(window).one 'click.emberui', (event) =>
+        if @get('targetObject')? && !$(event.target).parents('.eui-poplist').length
           event.preventDefault()
-          $(window).off(event)
           @hide()
 
   ).on 'didInsertElement'


### PR DESCRIPTION
This commit fixes the click event error as suggested by @jacojoubert at https://github.com/emberui/emberui/pull/40#issuecomment-43207335

It also use `$.one` instead of `$.on` + `$.off`, see http://api.jquery.com/one/
