### PR TITLE
move animation and utilities load into initalizer

### DIFF
--- a/lib/emberui.js
+++ b/lib/emberui.js
@@ -39,19 +39,6 @@ import EuiCalendarTemplate from './templates/eui-calendar';
 import EuiPopcalComponent from './components/eui-popcal';
 import EuiPopcalTemplate from './templates/eui-popcal';
 
-import './utilities/tabbable-selector';
-import './utilities/position';
-import './animations/popcal-close-default';
-import './animations/popcal-open-default';
-import './animations/modal-close-default';
-import './animations/modal-open-default';
-import './animations/modal-close-full';
-import './animations/modal-open-full';
-import './animations/poplist-close-default';
-import './animations/poplist-open-default';
-import './animations/poplist-close-flyin';
-import './animations/poplist-open-flyin';
-
 import EuiInitializer from './initializers/eui-initializer';
 
 

--- a/lib/initializers/eui-initializer.js
+++ b/lib/initializers/eui-initializer.js
@@ -1,3 +1,16 @@
+import '../utilities/tabbable-selector';
+import '../utilities/position';
+import '../animations/popcal-close-default';
+import '../animations/popcal-open-default';
+import '../animations/modal-close-default';
+import '../animations/modal-open-default';
+import '../animations/modal-close-full';
+import '../animations/modal-open-full';
+import '../animations/poplist-close-default';
+import '../animations/poplist-open-default';
+import '../animations/poplist-close-flyin';
+import '../animations/poplist-open-flyin';
+
 import EuiButtonComponent from '../components/eui-button';
 import EuiButtonTemplate from '../templates/eui-button';
 


### PR DESCRIPTION
as discussed, we should always load these even when one requires only the initializer like in the `ember-cli` use case 

/cc  @elucid @jacojoubert 
