### PR TITLE
Precompile inline templates

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -6,6 +6,7 @@ var compileSass         = require('broccoli-sass');
 var autoprefixer        = require('broccoli-autoprefixer');
 var mergeTrees = require('broccoli-merge-trees');
 var templateCompiler = require('broccoli-ember-hbs-template-compiler');
+var inlineTemplateCompiler = require('broccoli-ember-inline-template-compiler');
 var instrument = require('broccoli-debug').instrument;
 
 var lib                 = 'lib';
@@ -35,6 +36,8 @@ lib = mergeTrees([lib, templates]);
 lib = filterCoffeeScript(lib, {
   bare: true
 });
+
+lib = inlineTemplateCompiler(lib);
 
 lib = filterES6Modules(lib, {
   global:      'eui',

--- a/lib/components/eui-month.coffee
+++ b/lib/components/eui-month.coffee
@@ -1,7 +1,9 @@
-DATE_SLOT_HBS = Handlebars.compile(
-  '<li class="{{classNames}}" data-date="{{jsonDate}}">' +
-    '{{date}}' +
-  '</li>')
+precompileTemplate = Handlebars.compile
+
+DATE_SLOT_HBS = precompileTemplate('
+  <li class="{{unbound classNames}}" data-date="{{unbound jsonDate}}">
+    {{unbound date}}
+  </li>')
 
 
 containsDate = (dates, date) ->
@@ -96,6 +98,11 @@ month = Em.Component.extend
     unless month
       return
 
+    data = {
+      buffer: buff
+      view: view
+    }
+
     renderSlot = (slot) ->
       attrs
 
@@ -108,7 +115,7 @@ month = Em.Component.extend
 
         view.applyOptionsForDate(attrs, slot)
         attrs.classNames = attrs.classNames.join(' ')
-        buff.push(DATE_SLOT_HBS(attrs))
+        buff.push(DATE_SLOT_HBS(attrs, { data: data }))
 
       else
         buff.push('<li class="eui-slot eui-empty"></li>')

--- a/package.json
+++ b/package.json
@@ -18,15 +18,16 @@
   "devDependencies": {
     "bower": "1.3.2",
     "broccoli": "^0.9.0",
+    "broccoli-autoprefixer": "^0.2.0",
     "broccoli-coffee": "0.1.0",
-    "broccoli-template": "0.1.1",
+    "broccoli-debug": "~0.1.1",
+    "broccoli-dist-es6-module": "git+https://github.com/ghedamat/broccoli-dist-es6-module#mattia/use-main-name-for-all-builds",
+    "broccoli-ember-hbs-template-compiler": "^1.6.0",
+    "broccoli-ember-inline-template-compiler": "0.0.1",
+    "broccoli-env": "0.0.1",
+    "broccoli-merge-trees": "^0.1.3",
     "broccoli-sass": "0.1.2",
     "broccoli-static-compiler": "0.1.4",
-    "broccoli-env": "0.0.1",
-    "broccoli-autoprefixer": "^0.2.0",
-    "broccoli-dist-es6-module": "git+https://github.com/ghedamat/broccoli-dist-es6-module#mattia/use-main-name-for-all-builds",
-    "broccoli-merge-trees": "^0.1.3",
-    "broccoli-ember-hbs-template-compiler": "^1.5.0",
-    "broccoli-debug": "~0.1.1"
+    "broccoli-template": "0.1.1"
   }
 }


### PR DESCRIPTION
Note: had to slightly rejig the template because the addon uses `Ember.Handlebars.compile` instead of `Handlebars.compile`. This should be not quite as fast as `Handlebars.compile` but Fast Enough™.

Thanks @ghedamat and @mmun
