### PR TITLE
Respect Button Events

### DIFF
--- a/lib/components/eui-button.coffee
+++ b/lib/components/eui-button.coffee
@@ -23,8 +23,12 @@ button = Em.Component.extend className, disabledSupport, widthSupport,
   ariaHaspopup: null
 
   click: (event) ->
-    event.preventDefault()
-    @sendAction('action', @get('context'))
+    targetAction = @get 'action'
 
+    if targetAction
+      event.preventDefault()
+      @sendAction('action', @get('context'))
+    else
+      @_super(event)
 
 `export default button`


### PR DESCRIPTION
Ember UI was overriding the behaviour of the click action. This meant
that normal event behaviour on a click wasn't being respected, e.g.
clicking a submit button.